### PR TITLE
Suggested fix for date parsing

### DIFF
--- a/create_birthday_calendar.py
+++ b/create_birthday_calendar.py
@@ -13,9 +13,10 @@ import vobject
 
 
 def parse_date(date_str):
-    for date_fmt in ('%Y-%m-%d', '%Y%m%d', '--%m%d'):
+    no_year_fmt = '--%m%d;%Y'
+    for date_fmt in ('%Y-%m-%d', '%Y%m%d', no_year_fmt):
         try:
-            return datetime.strptime(date_str, date_fmt)
+            return datetime.strptime(date_str if date_fmt != no_year_fmt else f'{date_str};1904', date_fmt)
         except ValueError:
             pass
     raise ValueError(f'could not parse date {date_str}')


### PR DESCRIPTION
In Python 3.13, a date format with no year produces a DeprecationWarning (see https://docs.python.org/3/library/datetime.html#datetime.datetime.strptime). Fix prevents this warning as well as preventing a ValueError if a birthday of Feb 29 with no year is used.
```
Python 3.13.7 (main, Aug 15 2025, 23:40:34) [GCC 14.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import datetime
>>> datetime.datetime.strptime('--0228','--%m%d')
<python-input-1>:1: DeprecationWarning: Parsing dates involving a day of month without a year specified is ambiguious
and fails to parse leap day. The default behavior will change in Python 3.15
to either always raise an exception or to use a different default year (TBD).
To avoid trouble, add a specific year to the input & format.
See https://github.com/python/cpython/issues/70647.
datetime.datetime(1900, 2, 28, 0, 0)
>>> datetime.datetime.strptime('--0229','--%m%d')
Traceback (most recent call last):
  File "<python-input-2>", line 1, in <module>
    datetime.datetime.strptime('--0229','--%m%d')
    ~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/_strptime.py", line 800, in _strptime_datetime
    return cls(*args)
ValueError: day is out of range for month
>>> datetime.datetime.strptime('--0229;1904','--%m%d;%Y')
datetime.datetime(1904, 2, 29, 0, 0)
```